### PR TITLE
feat: Sorting of item list per url

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,9 +90,12 @@ Usage modes:
 			}
 		}
 
+		// Get tags using helper function (needed for both direct and interactive access)
+		tags := parseTags("")
+
 		// If we have both vault and item, get the item directly
 		if vault != "" && item != "" {
-			client := onepassword.NewClient(vault)
+			client := onepassword.NewClient(vault, tags...)
 			session, err := client.GetItem(vault, item)
 			if err != nil {
 				return err
@@ -105,8 +108,6 @@ Usage modes:
 		}
 
 		// If no specific item is requested, fall back to interactive list
-		// Get tags using helper function
-		tags := parseTags("")
 
 		client := onepassword.NewClient(vault, tags...)
 		sessions, err := client.List()

--- a/pkg/core/normalize_url_test.go
+++ b/pkg/core/normalize_url_test.go
@@ -72,7 +72,7 @@ func TestNormalizeURL(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := NormalizeURL(tc.input)
+			result := NormalizeDisplayURL(tc.input)
 			if result != tc.expected {
 				t.Errorf("NormalizeURL(%q) = %q; expected %q", tc.input, result, tc.expected)
 			}

--- a/pkg/core/normalize_url_test.go
+++ b/pkg/core/normalize_url_test.go
@@ -1,0 +1,81 @@
+package core
+
+import "testing"
+
+func TestNormalizeURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "HTTPS URL with trailing slash",
+			input:    "https://example.com/",
+			expected: "example.com",
+		},
+		{
+			name:     "HTTP URL with trailing slash",
+			input:    "http://example.com/",
+			expected: "example.com",
+		},
+		{
+			name:     "HTTPS URL without trailing slash",
+			input:    "https://example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "HTTP URL without trailing slash",
+			input:    "http://example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "FTP URL",
+			input:    "ftp://files.example.com/",
+			expected: "files.example.com",
+		},
+		{
+			name:     "Custom protocol",
+			input:    "myprotocol://custom.example.com/",
+			expected: "custom.example.com",
+		},
+		{
+			name:     "No protocol",
+			input:    "example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "No protocol with trailing slash",
+			input:    "example.com/",
+			expected: "example.com",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Complex URL with path",
+			input:    "https://api.example.com/v1/endpoint/",
+			expected: "api.example.com/v1/endpoint",
+		},
+		{
+			name:     "URL with port",
+			input:    "https://example.com:8080/",
+			expected: "example.com:8080",
+		},
+		{
+			name:     "URL with subdomain",
+			input:    "https://api.tenant.cumulocity.com/",
+			expected: "api.tenant.cumulocity.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := NormalizeURL(tc.input)
+			if result != tc.expected {
+				t.Errorf("NormalizeURL(%q) = %q; expected %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/core/session.go
+++ b/pkg/core/session.go
@@ -5,6 +5,30 @@ import (
 	"strings"
 )
 
+// NormalizeURL removes protocol and trailing slash for better display and sorting
+// Uses robust protocol parsing by splitting on "://" separator
+func NormalizeURL(url string) string {
+	if url == "" {
+		return url
+	}
+
+	// Split on "://" to handle any protocol (http, https, ftp, etc.)
+	parts := strings.Split(url, "://")
+	var normalized string
+	if len(parts) > 1 {
+		// Use the part after the protocol
+		normalized = parts[1]
+	} else {
+		// No protocol found, use the original URL
+		normalized = url
+	}
+
+	// Remove trailing slash
+	normalized = strings.TrimSuffix(normalized, "/")
+
+	return normalized
+}
+
 type CumulocitySession struct {
 	SessionURI string `json:"sessionUri,omitempty"`
 	Name       string `json:"name,omitempty"`
@@ -27,7 +51,9 @@ func (i CumulocitySession) FilterValue() string {
 	return strings.Join([]string{i.SessionURI, i.Host, i.Username}, " ")
 }
 
-func (i CumulocitySession) Title() string { return i.Host }
+func (i CumulocitySession) Title() string {
+	return NormalizeURL(i.Host)
+}
 
 func (i CumulocitySession) Description() string {
 	fields := []string{
@@ -40,11 +66,6 @@ func (i CumulocitySession) Description() string {
 	if i.Tenant != "" {
 		fields = append(fields, ", Tenant=%s")
 		args = append(args, i.Tenant)
-	}
-
-	if i.VaultName != "" {
-		fields = append(fields, ", Vault=%s")
-		args = append(args, i.VaultName)
 	}
 
 	if len(i.Tags) > 0 {

--- a/pkg/core/session.go
+++ b/pkg/core/session.go
@@ -5,9 +5,60 @@ import (
 	"strings"
 )
 
-// NormalizeURL removes protocol and trailing slash for better display and sorting
+type CumulocitySession struct {
+	SessionURI string `json:"sessionUri,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Host       string `json:"host,omitempty"`
+	Username   string `json:"username,omitempty"`
+	Password   string `json:"password,omitempty"`
+	Tenant     string `json:"tenant,omitempty"`
+	TOTP       string `json:"totp,omitempty"`
+	TOTPSecret string `json:"totpSecret,omitempty"`
+
+	// 1Password specific
+	ItemID    string   `json:"itemId,omitempty"`
+	ItemName  string   `json:"itemName,omitempty"`
+	VaultID   string   `json:"vaultId,omitempty"`
+	VaultName string   `json:"vaultName,omitempty"`
+	Tags      []string `json:"tags,omitempty"` // Only the matching requested tags
+}
+
+// URLSource represents a URL from any source (URLs array or fields)
+type URLSource struct {
+	URL     string
+	Label   string
+	Primary bool
+	Source  string // "urls" or "field"
+}
+
+// ItemFields contains extracted fields from a 1Password item
+type ItemFields struct {
+	Username   string
+	Password   string
+	TOTPSecret string
+	Tenant     string
+}
+
+// Item represents a simplified 1Password item for session creation
+type Item struct {
+	ID    string
+	Title string
+	Tags  []string
+	Vault Vault
+}
+
+// Vault represents a 1Password vault
+type Vault struct {
+	ID   string
+	Name string
+}
+
+// Session building utilities
+// These handle the creation and management of sessions from 1Password items
+
+// NormalizeDisplayURL removes protocol and trailing slash for better display and sorting
 // Uses robust protocol parsing by splitting on "://" separator
-func NormalizeURL(url string) string {
+func NormalizeDisplayURL(url string) string {
 	if url == "" {
 		return url
 	}
@@ -29,30 +80,12 @@ func NormalizeURL(url string) string {
 	return normalized
 }
 
-type CumulocitySession struct {
-	SessionURI string `json:"sessionUri,omitempty"`
-	Name       string `json:"name,omitempty"`
-	Host       string `json:"host,omitempty"`
-	Username   string `json:"username,omitempty"`
-	Password   string `json:"password,omitempty"`
-	Tenant     string `json:"tenant,omitempty"`
-	TOTP       string `json:"totp,omitempty"`
-	TOTPSecret string `json:"totpSecret,omitempty"`
-
-	// 1Password specific
-	ItemID    string   `json:"itemId,omitempty"`
-	ItemName  string   `json:"itemName,omitempty"`
-	VaultID   string   `json:"vaultId,omitempty"`
-	VaultName string   `json:"vaultName,omitempty"`
-	Tags      []string `json:"tags,omitempty"`
-}
-
 func (i CumulocitySession) FilterValue() string {
 	return strings.Join([]string{i.SessionURI, i.Host, i.Username}, " ")
 }
 
 func (i CumulocitySession) Title() string {
-	return NormalizeURL(i.Host)
+	return NormalizeDisplayURL(i.Host)
 }
 
 func (i CumulocitySession) Description() string {
@@ -73,8 +106,168 @@ func (i CumulocitySession) Description() string {
 		args = append(args, strings.Join(i.Tags, ","))
 	}
 
-	fields = append(fields, " | uri=%s")
-	args = append(args, i.SessionURI)
+	fields = append(fields, " | %s")
+	var vault, item, session string
+	vault = i.VaultName
+	if vault == "" {
+		vault = i.VaultID
+	}
+	item = i.ItemName
+	if item == "" {
+		item = i.ItemID
+	}
+
+	session = i.SessionURI
+	if item != "" && vault != "" {
+		session = BuildSessionURI(vault, item)
+	}
+	args = append(args, session)
 
 	return fmt.Sprintf(strings.Join(fields, ""), args...)
+}
+
+// BuildSessionName creates an appropriate name for a session based on URL source and count
+func BuildSessionName(item Item, urlSource URLSource, urlIndex int, totalURLs int, labelCounts map[string]int) string {
+	if totalURLs == 1 {
+		return item.Title
+	}
+
+	// If current URL's label appears multiple times, use hostname for distinction
+	if labelCounts[urlSource.Label] > 1 {
+		hostname := extractHostname(urlSource.URL)
+		if urlSource.Primary {
+			return fmt.Sprintf("%s (%s - Primary)", item.Title, hostname)
+		}
+		return fmt.Sprintf("%s (%s)", item.Title, hostname)
+	}
+
+	if urlSource.Label != "" && urlSource.Label != "website" {
+		return fmt.Sprintf("%s (%s)", item.Title, urlSource.Label)
+	}
+
+	if urlSource.Primary {
+		return fmt.Sprintf("%s (Primary)", item.Title)
+	}
+
+	return fmt.Sprintf("%s (URL %d)", item.Title, urlIndex+1)
+}
+
+func BuildSessionURI(vault, item string) string {
+	return fmt.Sprintf("op://%s/%s", vault, item)
+}
+
+// CreateSession builds a CumulocitySession from extracted data
+// If useFiltering is true, filteredTags will be used; otherwise all item tags are used
+func CreateSession(item Item, fields ItemFields, vaultName string, urlSource URLSource, sessionName, sessionURI string, filteredTags []string, useFiltering bool) *CumulocitySession {
+	var tags []string
+	if useFiltering {
+		tags = filteredTags // Use filtered tags (could be empty)
+	} else {
+		tags = item.Tags // Use all item tags
+	}
+
+	return &CumulocitySession{
+		SessionURI: sessionURI,
+		Name:       sessionName,
+		ItemID:     item.ID,
+		ItemName:   item.Title,
+		Username:   fields.Username,
+		Password:   fields.Password,
+		Tenant:     fields.Tenant,
+		Host:       urlSource.URL,
+		VaultID:    item.Vault.ID,
+		VaultName:  vaultName,
+		TOTPSecret: fields.TOTPSecret,
+		Tags:       tags,
+	}
+}
+
+// FilterMatchingTags returns only the tags from item that match the requested tags
+func FilterMatchingTags(itemTags []string, requestedTags []string) []string {
+	if len(requestedTags) == 0 {
+		return nil // Return nil to indicate no filtering should be done
+	}
+
+	var matchingTags []string
+	for _, itemTag := range itemTags {
+		for _, requestedTag := range requestedTags {
+			if strings.EqualFold(itemTag, requestedTag) {
+				matchingTags = append(matchingTags, itemTag)
+				break
+			}
+		}
+	}
+	return matchingTags
+}
+
+// MapToSessions creates one or more sessions from a 1Password item, handling multiple URLs
+// If requestedTags is provided, only matching tags will be included in the sessions
+func MapToSessions(item Item, fields ItemFields, allURLs []URLSource, vaultName string, requestedTags []string) []*CumulocitySession {
+	// Filter tags if requested
+	var filteredTags []string
+	var useFiltering bool
+	if len(requestedTags) > 0 {
+		filteredTags = FilterMatchingTags(item.Tags, requestedTags)
+		useFiltering = true
+	}
+
+	// If no URLs found anywhere, create one session without URL
+	if len(allURLs) == 0 {
+		emptyURL := URLSource{URL: "", Label: "", Primary: false, Source: "none"}
+		sessionName := BuildSessionName(item, emptyURL, 0, 1, nil)
+		sessionURI := BuildSessionURI(item.Vault.ID, item.ID)
+		session := CreateSession(item, fields, vaultName, emptyURL, sessionName, sessionURI, filteredTags, useFiltering)
+		return []*CumulocitySession{session}
+	}
+
+	// Pre-calculate label counts for naming decisions
+	labelCounts := make(map[string]int)
+	for _, url := range allURLs {
+		labelCounts[url.Label]++
+	}
+
+	// Create sessions for all URLs
+	sessions := make([]*CumulocitySession, 0, len(allURLs))
+	for i, urlSource := range allURLs {
+		sessionName := BuildSessionName(item, urlSource, i, len(allURLs), labelCounts)
+		sessionURI := BuildSessionURI(item.Vault.ID, item.ID)
+		session := CreateSession(item, fields, vaultName, urlSource, sessionName, sessionURI, filteredTags, useFiltering)
+		sessions = append(sessions, session)
+	}
+
+	return sessions
+}
+
+// extractHostname extracts a meaningful hostname part for display
+func extractHostname(urlStr string) string {
+	// Remove protocol
+	hostname := NormalizeDisplayURL(urlStr)
+
+	// Remove trailing slash and path
+	if idx := strings.Index(hostname, "/"); idx != -1 {
+		hostname = hostname[:idx]
+	}
+
+	// For cases like "integration-tests-01.dtm-dev.stage.c8y.io",
+	// extract the meaningful part before the common domain
+	parts := strings.Split(hostname, ".")
+	if len(parts) > 0 {
+		// Take the first part which is usually the most meaningful
+		firstPart := parts[0]
+
+		// For very long hostnames, try to get a shorter meaningful name
+		if len(firstPart) > 20 {
+			// If it contains hyphens, take parts around them
+			if strings.Contains(firstPart, "-") {
+				subParts := strings.Split(firstPart, "-")
+				if len(subParts) >= 2 {
+					return strings.Join(subParts[:2], "-")
+				}
+			}
+			return firstPart[:20] + "..."
+		}
+		return firstPart
+	}
+
+	return hostname
 }

--- a/pkg/core/session_tags_simple_test.go
+++ b/pkg/core/session_tags_simple_test.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestSessionTagsSimple(t *testing.T) {
+	// Test session with only matching tags
+	session := CumulocitySession{
+		Name:       "Test Session",
+		Host:       "https://test.example.com",
+		Username:   "testuser",
+		Tags:       []string{"c8y"}, // Only matching tags, not all item tags
+		SessionURI: "op://vault/item",
+	}
+
+	description := session.Description()
+	expected := "Username=testuser, Tags=c8y | op://vault/item"
+
+	if description != expected {
+		t.Errorf("Expected description %q, got %q", expected, description)
+	}
+}
+
+func TestSessionMultipleMatchingTags(t *testing.T) {
+	// Test session with multiple matching tags
+	session := CumulocitySession{
+		Name:       "Test Session",
+		Host:       "https://test.example.com",
+		Username:   "testuser",
+		Tenant:     "testtenant",
+		Tags:       []string{"c8y", "prod"}, // Only the requested/matching tags
+		SessionURI: "op://vault/item",
+	}
+
+	description := session.Description()
+	expected := "Username=testuser, Tenant=testtenant, Tags=c8y,prod | op://vault/item"
+
+	if description != expected {
+		t.Errorf("Expected description %q, got %q", expected, description)
+	}
+}
+
+func TestSessionNoTags(t *testing.T) {
+	// Test session with no tags
+	session := CumulocitySession{
+		Name:       "Test Session",
+		Host:       "https://test.example.com",
+		Username:   "testuser",
+		Tags:       []string{}, // No tags
+		SessionURI: "op://vault/item",
+	}
+
+	description := session.Description()
+	expected := "Username=testuser | op://vault/item"
+
+	if description != expected {
+		t.Errorf("Expected description %q, got %q", expected, description)
+	}
+}

--- a/pkg/core/session_test.go
+++ b/pkg/core/session_test.go
@@ -24,7 +24,7 @@ func TestCumulocitySession_Title(t *testing.T) {
 		Host: "https://example.cumulocity.com",
 	}
 
-	expected := "https://example.cumulocity.com"
+	expected := "example.cumulocity.com"
 	result := session.Title()
 
 	if result != expected {
@@ -44,10 +44,10 @@ func TestCumulocitySession_Description(t *testing.T) {
 	result := session.Description()
 
 	// Check that all expected components are in the description
+	// Note: Vault is excluded from description to save space (it's in the URI)
 	expectedParts := []string{
 		"Username=testuser",
 		"Tenant=testtenant",
-		"Vault=testvault",
 		"Tags=c8y,test",
 		"uri=op://Employee/test-item",
 	}
@@ -56,6 +56,11 @@ func TestCumulocitySession_Description(t *testing.T) {
 		if !contains(result, part) {
 			t.Errorf("Description() = %q; expected to contain %q", result, part)
 		}
+	}
+
+	// Ensure vault is NOT in the description (space saving)
+	if contains(result, "Vault=testvault") {
+		t.Errorf("Description() = %q; should not contain vault (space saving)", result)
 	}
 }
 

--- a/pkg/core/session_test.go
+++ b/pkg/core/session_test.go
@@ -49,7 +49,7 @@ func TestCumulocitySession_Description(t *testing.T) {
 		"Username=testuser",
 		"Tenant=testtenant",
 		"Tags=c8y,test",
-		"uri=op://Employee/test-item",
+		"op://Employee/test-item",
 	}
 
 	for _, part := range expectedParts {

--- a/pkg/core/session_vault_test.go
+++ b/pkg/core/session_vault_test.go
@@ -21,7 +21,7 @@ func TestCumulocitySession_Description_NoVault(t *testing.T) {
 		"Username=testuser",
 		"Tenant=testtenant",
 		"Tags=c8y",
-		"uri=op://MyVault/test-item",
+		"op://MyVault/test-item",
 	}
 
 	for _, part := range expectedParts {
@@ -49,7 +49,7 @@ func TestCumulocitySession_Description_Minimal(t *testing.T) {
 	}
 
 	result := session.Description()
-	expected := "Username=user | uri=op://Vault/Item"
+	expected := "Username=user | op://Vault/Item"
 
 	if result != expected {
 		t.Errorf("Description() = %q; expected %q", result, expected)

--- a/pkg/core/session_vault_test.go
+++ b/pkg/core/session_vault_test.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestCumulocitySession_Description_NoVault(t *testing.T) {
+	// Test to ensure vault is excluded from description to save space
+	session := CumulocitySession{
+		Username:   "testuser",
+		Tenant:     "testtenant",
+		VaultName:  "MyVault",
+		Tags:       []string{"c8y"},
+		SessionURI: "op://MyVault/test-item",
+	}
+
+	result := session.Description()
+
+	// Should contain username, tenant, tags, and URI
+	expectedParts := []string{
+		"Username=testuser",
+		"Tenant=testtenant",
+		"Tags=c8y",
+		"uri=op://MyVault/test-item",
+	}
+
+	for _, part := range expectedParts {
+		if !contains(result, part) {
+			t.Errorf("Description() = %q; expected to contain %q", result, part)
+		}
+	}
+
+	// Should NOT contain vault (since it's in the URI already)
+	if contains(result, "Vault=MyVault") {
+		t.Errorf("Description() = %q; should not contain vault name (space saving)", result)
+	}
+
+	// Should NOT contain "Vault=" at all
+	if contains(result, "Vault=") {
+		t.Errorf("Description() = %q; should not contain any vault information", result)
+	}
+}
+
+func TestCumulocitySession_Description_Minimal(t *testing.T) {
+	// Test minimal session with just username
+	session := CumulocitySession{
+		Username:   "user",
+		SessionURI: "op://Vault/Item",
+	}
+
+	result := session.Description()
+	expected := "Username=user | uri=op://Vault/Item"
+
+	if result != expected {
+		t.Errorf("Description() = %q; expected %q", result, expected)
+	}
+}

--- a/pkg/onepassword/client.go
+++ b/pkg/onepassword/client.go
@@ -21,11 +21,70 @@ type Client struct {
 	Tags  []string
 }
 
+type Vault struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// OPItem 1Password item containing the login information
+type OPItem struct {
+	ID       string    `json:"id"`
+	Title    string    `json:"title"`
+	Category string    `json:"category"`
+	Vault    OPVault   `json:"vault"`
+	Fields   []OPField `json:"fields"`
+	URLs     []OPURL   `json:"urls"`
+	Tags     []string  `json:"tags"`
+}
+
 func NewClient(vault string, tags ...string) *Client {
 	return &Client{
 		Vault: vault,
 		Tags:  tags,
 	}
+}
+
+// OPField 1Password custom fields
+type OPField struct {
+	ID          string        `json:"id"`
+	Type        string        `json:"type"`
+	Purpose     string        `json:"purpose"`
+	Label       string        `json:"label"`
+	Value       string        `json:"value"`
+	TOTPDetails OPTOTPDetails `json:"totp,omitempty"`
+}
+
+type OPTOTPDetails struct {
+	Secret string `json:"secret"`
+}
+
+// OPVault 1Password vault information
+type OPVault struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// OPURL 1Password URL associated with the login credentials
+type OPURL struct {
+	Label   string `json:"label"`
+	Primary bool   `json:"primary"`
+	Href    string `json:"href"`
+}
+
+// URLSource represents a URL from any source (URLs array or fields)
+type URLSource struct {
+	URL     string
+	Label   string
+	Primary bool
+	Source  string // "urls" or "field"
+}
+
+// extractItemFields extracts common fields from a 1Password item
+type itemFields struct {
+	username   string
+	password   string
+	totpSecret string
+	tenant     string
 }
 
 // parseVaultNamesFromString splits a comma-separated vault string and returns a slice of vault names
@@ -53,17 +112,6 @@ func parseVaultNamesFromString(vaultStr string) []string {
 // parseVaultNames splits a comma-separated vault string and returns a slice of vault names
 func (c *Client) parseVaultNames() []string {
 	return parseVaultNamesFromString(c.Vault)
-}
-
-// OPItem 1Password item containing the login information
-type OPItem struct {
-	ID       string    `json:"id"`
-	Title    string    `json:"title"`
-	Category string    `json:"category"`
-	Vault    OPVault   `json:"vault"`
-	Fields   []OPField `json:"fields"`
-	URLs     []OPURL   `json:"urls"`
-	Tags     []string  `json:"tags"`
 }
 
 func (opi *OPItem) HasTenantField() bool {
@@ -112,41 +160,6 @@ func (opi *OPItem) GetTOTPSecret() string {
 	return fields.totpSecret
 }
 
-// OPField 1Password custom fields
-type OPField struct {
-	ID          string        `json:"id"`
-	Type        string        `json:"type"`
-	Purpose     string        `json:"purpose"`
-	Label       string        `json:"label"`
-	Value       string        `json:"value"`
-	TOTPDetails OPTOTPDetails `json:"totp,omitempty"`
-}
-
-type OPTOTPDetails struct {
-	Secret string `json:"secret"`
-}
-
-// OPVault 1Password vault information
-type OPVault struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-// OPURL 1Password URL associated with the login credentials
-type OPURL struct {
-	Label   string `json:"label"`
-	Primary bool   `json:"primary"`
-	Href    string `json:"href"`
-}
-
-// URLSource represents a URL from any source (URLs array or fields)
-type URLSource struct {
-	URL     string
-	Label   string
-	Primary bool
-	Source  string // "urls" or "field"
-}
-
 func check1Password() error {
 	if _, err := safeexec.LookPath("op"); err != nil {
 		return fmt.Errorf("could not find 'op' (1Password CLI). Check if it is installed on your machine")
@@ -159,14 +172,6 @@ func check1Password() error {
 	}
 
 	return nil
-}
-
-// extractItemFields extracts common fields from a 1Password item
-type itemFields struct {
-	username   string
-	password   string
-	totpSecret string
-	tenant     string
 }
 
 func (opi *OPItem) extractFields() itemFields {
@@ -248,137 +253,54 @@ func (opi *OPItem) collectURLs() []URLSource {
 	return allURLs
 }
 
-// buildSessionName creates an appropriate name for a session based on URL source and count
-func buildSessionName(item *OPItem, urlSource URLSource, urlIndex int, totalURLs int, labelCounts map[string]int) string {
-	if totalURLs == 1 {
-		return item.Title
-	}
-
-	// If current URL's label appears multiple times, use hostname for distinction
-	if labelCounts[urlSource.Label] > 1 {
-		hostname := extractHostname(urlSource.URL)
-		if urlSource.Primary {
-			return fmt.Sprintf("%s (%s - Primary)", item.Title, hostname)
-		}
-		return fmt.Sprintf("%s (%s)", item.Title, hostname)
-	}
-
-	if urlSource.Label != "" && urlSource.Label != "website" {
-		return fmt.Sprintf("%s (%s)", item.Title, urlSource.Label)
-	}
-
-	if urlSource.Primary {
-		return fmt.Sprintf("%s (Primary)", item.Title)
-	}
-
-	return fmt.Sprintf("%s (URL %d)", item.Title, urlIndex+1)
-}
-
-// buildSessionURI creates an appropriate URI for a session using vault ID and item ID for shorter URIs
-func buildSessionURI(vaultID, itemID string, urlSource URLSource, urlIndex int, totalURLs int, labelCounts map[string]int) string {
-	baseURI := fmt.Sprintf("op://%s/%s", vaultID, itemID)
-	if totalURLs == 1 {
-		return baseURI
-	}
-
-	var fragment string
-	if labelCounts[urlSource.Label] > 1 {
-		hostname := extractHostname(urlSource.URL)
-		if urlSource.Primary {
-			fragment = hostname + "-primary"
-		} else {
-			fragment = hostname
-		}
-	} else if urlSource.Label != "" && urlSource.Label != "website" {
-		fragment = urlSource.Label
-	} else if urlSource.Primary {
-		fragment = "primary"
-	} else {
-		fragment = fmt.Sprintf("url%d", urlIndex+1)
-	}
-
-	return fmt.Sprintf("%s#%s", baseURI, fragment)
-}
-
-// createSession builds a CumulocitySession from extracted data
-func createSession(item *OPItem, fields itemFields, vaultName string, urlSource URLSource, sessionName, sessionURI string) *core.CumulocitySession {
-	return &core.CumulocitySession{
-		SessionURI: sessionURI,
-		Name:       sessionName,
-		ItemID:     item.ID,
-		ItemName:   item.Title,
-		Username:   fields.username,
-		Password:   fields.password,
-		Tenant:     fields.tenant,
-		Host:       urlSource.URL,
-		VaultID:    item.Vault.ID,
-		VaultName:  vaultName,
-		TOTPSecret: fields.totpSecret,
-		Tags:       item.Tags,
-	}
-}
-
-func mapToSession(item *OPItem, vaults map[string]string) *core.CumulocitySession {
-	// Use mapToSessions and return the first session for backward compatibility
-	sessions := mapToSessions(item, vaults)
-	if len(sessions) > 0 {
-		return sessions[0]
-	}
-	return nil
-}
-
 // mapToSessions creates one or more sessions from a 1Password item, handling multiple URLs
-func mapToSessions(item *OPItem, vaults map[string]string) []*core.CumulocitySession {
+func (c *Client) mapToSessions(item *OPItem, vaults map[string]string) []*core.CumulocitySession {
 	// Determine vault name for URI
 	vaultName := item.Vault.Name
 	if name, found := vaults[item.Vault.ID]; found {
 		vaultName = name
 	}
 
-	// Extract all fields at once
+	// Convert to core types
+	coreItem := core.Item{
+		ID:    item.ID,
+		Title: item.Title,
+		Tags:  item.Tags,
+		Vault: core.Vault{
+			ID:   item.Vault.ID,
+			Name: item.Vault.Name,
+		},
+	}
+
+	// Extract fields
 	fields := item.extractFields()
+	coreFields := core.ItemFields{
+		Username:   fields.username,
+		Password:   fields.password,
+		TOTPSecret: fields.totpSecret,
+		Tenant:     fields.tenant,
+	}
 
-	// Collect all URLs from both sources
+	// Collect URLs
 	allURLs := item.collectURLs()
-
-	// If no URLs found anywhere, create one session without URL
-	if len(allURLs) == 0 {
-		emptyURL := URLSource{URL: "", Label: "", Primary: false, Source: "none"}
-		sessionName := buildSessionName(item, emptyURL, 0, 1, nil)
-		sessionURI := buildSessionURI(item.Vault.ID, item.ID, emptyURL, 0, 1, nil)
-		session := createSession(item, fields, vaultName, emptyURL, sessionName, sessionURI)
-		result := make([]*core.CumulocitySession, 1)
-		result[0] = session
-		return result
+	coreURLs := make([]core.URLSource, len(allURLs))
+	for i, url := range allURLs {
+		coreURLs[i] = core.URLSource{
+			URL:     url.URL,
+			Label:   url.Label,
+			Primary: url.Primary,
+			Source:  url.Source,
+		}
 	}
 
-	// Pre-calculate label counts for naming decisions
-	labelCounts := make(map[string]int)
-	for _, url := range allURLs {
-		labelCounts[url.Label]++
-	}
-
-	// Create sessions for all URLs
-	sessions := make([]*core.CumulocitySession, 0, len(allURLs))
-	for i, urlSource := range allURLs {
-		sessionName := buildSessionName(item, urlSource, i, len(allURLs), labelCounts)
-		sessionURI := buildSessionURI(item.Vault.ID, item.ID, urlSource, i, len(allURLs), labelCounts)
-		session := createSession(item, fields, vaultName, urlSource, sessionName, sessionURI)
-		sessions = append(sessions, session)
-	}
-
-	return sessions
+	// Use unified session mapping with tag filtering
+	return core.MapToSessions(coreItem, coreFields, coreURLs, vaultName, c.Tags)
 }
 
 func isUID(v string) bool {
 	// 1Password item IDs are different format than UUIDs
 	r := regexp.MustCompile("^[a-zA-Z0-9]{26}$")
 	return r.MatchString(v)
-}
-
-type Vault struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
 }
 
 func (c *Client) ListVaults(name ...string) (map[string]string, error) {
@@ -457,8 +379,8 @@ func (c *Client) List(name ...string) ([]*core.CumulocitySession, error) {
 	// Sort sessions by Host URL for better organization
 	sort.Slice(allSessions, func(i, j int) bool {
 		// Normalize URLs for better sorting (remove protocol and trailing slash)
-		normalizedI := core.NormalizeURL(allSessions[i].Host)
-		normalizedJ := core.NormalizeURL(allSessions[j].Host)
+		normalizedI := core.NormalizeDisplayURL(allSessions[i].Host)
+		normalizedJ := core.NormalizeDisplayURL(allSessions[j].Host)
 		return normalizedI < normalizedJ
 	})
 
@@ -572,7 +494,7 @@ func (c *Client) listFromVault(vaultName string) ([]*core.CumulocitySession, err
 		}
 
 		// Create sessions for this item (may create multiple sessions for multiple URLs)
-		itemSessions := mapToSessions(&item, vaults)
+		itemSessions := c.mapToSessions(&item, vaults)
 		sessions = append(sessions, itemSessions...)
 	}
 
@@ -763,41 +685,10 @@ func (c *Client) getItemFromVault(vaultIdentifier, itemIdentifier string) (*core
 		vaults = make(map[string]string)
 	}
 
-	session := mapToSession(&item, vaults)
-	return session, nil
-}
-
-// extractHostname extracts a meaningful hostname part for display
-func extractHostname(urlStr string) string {
-	// Remove protocol
-	hostname := strings.TrimPrefix(urlStr, "https://")
-	hostname = strings.TrimPrefix(hostname, "http://")
-
-	// Remove trailing slash and path
-	if idx := strings.Index(hostname, "/"); idx != -1 {
-		hostname = hostname[:idx]
+	// Use mapToSessions to get properly formatted sessions
+	sessions := c.mapToSessions(&item, vaults)
+	if len(sessions) > 0 {
+		return sessions[0], nil
 	}
-
-	// For cases like "integration-tests-01.dtm-dev.stage.c8y.io",
-	// extract the meaningful part before the common domain
-	parts := strings.Split(hostname, ".")
-	if len(parts) > 0 {
-		// Take the first part which is usually the most meaningful
-		firstPart := parts[0]
-
-		// For very long hostnames, try to get a shorter meaningful name
-		if len(firstPart) > 20 {
-			// If it contains hyphens, take parts around them
-			if strings.Contains(firstPart, "-") {
-				subParts := strings.Split(firstPart, "-")
-				if len(subParts) >= 2 {
-					return strings.Join(subParts[:2], "-")
-				}
-			}
-			return firstPart[:20] + "..."
-		}
-		return firstPart
-	}
-
-	return hostname
+	return nil, fmt.Errorf("no valid session found for item")
 }

--- a/pkg/onepassword/client_tags_test.go
+++ b/pkg/onepassword/client_tags_test.go
@@ -1,0 +1,208 @@
+package onepassword
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/thomaswinkler/c8y-session-1password/pkg/core"
+)
+
+func TestCreateSessionWithTags_FiltersTags(t *testing.T) {
+	client := NewClient("test-vault", "c8y", "prod")
+
+	// Mock item with multiple tags
+	item := &OPItem{
+		ID:    "test-id",
+		Title: "Test Service",
+		Tags:  []string{"Shared", "C8Y instances", "DTM", "c8y", "production", "test"},
+		URLs: []OPURL{
+			{Href: "https://test.cumulocity.com"},
+		},
+		Fields: []OPField{
+			{ID: "username", Value: "testuser"},
+			{ID: "password", Value: "testpass"},
+		},
+		Vault: OPVault{
+			ID:   "vault123",
+			Name: "TestVault",
+		},
+	}
+
+	// Extract fields and URLs
+	fields := item.extractFields()
+	vaultName := "TestVault"
+	urlSource := URLSource{URL: "https://test.cumulocity.com", Label: "", Primary: false, Source: "urls"}
+	sessionName := "Test Service"
+	sessionURI := "op://vault123/test-id"
+
+	session := client.createSessionWithTags(item, fields, vaultName, urlSource, sessionName, sessionURI)
+
+	// Should only contain matching tags from requested tags: "c8y", "prod"
+	// From item tags ["Shared", "C8Y instances", "DTM", "c8y", "production", "test"]
+	// Should match: "c8y" (exact match)
+	// "prod" doesn't match anything (case-insensitive exact matching)
+	expectedTags := []string{"c8y"}
+
+	if len(session.Tags) != len(expectedTags) {
+		t.Errorf("Expected %d tags, got %d: %v", len(expectedTags), len(session.Tags), session.Tags)
+	}
+
+	for _, expectedTag := range expectedTags {
+		found := false
+		for _, sessionTag := range session.Tags {
+			if strings.EqualFold(sessionTag, expectedTag) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected tag '%s' not found in session tags: %v", expectedTag, session.Tags)
+		}
+	}
+
+	// Test the display
+	description := session.Description()
+	if !strings.Contains(description, "Tags=c8y") {
+		t.Errorf("Expected description to contain 'Tags=c8y', got: %s", description)
+	}
+
+	// Should not contain unmatched tags
+	if strings.Contains(description, "Shared") || strings.Contains(description, "DTM") {
+		t.Errorf("Description should not contain unmatched tags, got: %s", description)
+	}
+}
+
+func TestCreateSessionWithTags_NoMatchingTags(t *testing.T) {
+	client := NewClient("test-vault", "nonexistent")
+
+	item := &OPItem{
+		ID:    "test-id",
+		Title: "Test Service",
+		Tags:  []string{"Shared", "C8Y instances", "DTM"},
+		URLs: []OPURL{
+			{Href: "https://test.cumulocity.com"},
+		},
+		Fields: []OPField{
+			{ID: "username", Value: "testuser"},
+			{ID: "password", Value: "testpass"},
+		},
+		Vault: OPVault{
+			ID:   "vault123",
+			Name: "TestVault",
+		},
+	}
+
+	// Extract fields and URLs
+	fields := item.extractFields()
+	vaultName := "TestVault"
+	urlSource := URLSource{URL: "https://test.cumulocity.com", Label: "", Primary: false, Source: "urls"}
+	sessionName := "Test Service"
+	sessionURI := "op://vault123/test-id"
+
+	session := client.createSessionWithTags(item, fields, vaultName, urlSource, sessionName, sessionURI)
+
+	// Should have no tags since none match
+	if len(session.Tags) != 0 {
+		t.Errorf("Expected 0 tags, got %d: %v", len(session.Tags), session.Tags)
+	}
+
+	// Description should not show Tags section when no tags
+	description := session.Description()
+	if strings.Contains(description, "Tags=") {
+		t.Errorf("Description should not contain 'Tags=' when no matching tags, got: %s", description)
+	}
+}
+
+func TestCreateSessionWithTags_CaseInsensitive(t *testing.T) {
+	client := NewClient("test-vault", "C8Y", "shared")
+
+	item := &OPItem{
+		ID:    "test-id",
+		Title: "Test Service",
+		Tags:  []string{"Shared", "c8y", "production"},
+		URLs: []OPURL{
+			{Href: "https://test.cumulocity.com"},
+		},
+		Fields: []OPField{
+			{ID: "username", Value: "testuser"},
+			{ID: "password", Value: "testpass"},
+		},
+		Vault: OPVault{
+			ID:   "vault123",
+			Name: "TestVault",
+		},
+	}
+
+	// Extract fields and URLs
+	fields := item.extractFields()
+	vaultName := "TestVault"
+	urlSource := URLSource{URL: "https://test.cumulocity.com", Label: "", Primary: false, Source: "urls"}
+	sessionName := "Test Service"
+	sessionURI := "op://vault123/test-id"
+
+	session := client.createSessionWithTags(item, fields, vaultName, urlSource, sessionName, sessionURI)
+
+	// Should match both "C8Y" -> "c8y" and "shared" -> "Shared" (case insensitive)
+	expectedCount := 2
+	if len(session.Tags) != expectedCount {
+		t.Errorf("Expected %d tags, got %d: %v", expectedCount, len(session.Tags), session.Tags)
+	}
+
+	// Check that both tags are present (preserving original case from item)
+	hasC8Y := false
+	hasShared := false
+	for _, tag := range session.Tags {
+		if strings.EqualFold(tag, "c8y") {
+			hasC8Y = true
+		}
+		if strings.EqualFold(tag, "shared") {
+			hasShared = true
+		}
+	}
+
+	if !hasC8Y {
+		t.Errorf("Expected to find 'c8y' tag, got: %v", session.Tags)
+	}
+	if !hasShared {
+		t.Errorf("Expected to find 'Shared' tag, got: %v", session.Tags)
+	}
+}
+
+// Helper function for testing tag filtering behavior
+func (c *Client) createSessionWithTags(item *OPItem, fields itemFields, vaultName string, urlSource URLSource, sessionName, sessionURI string) *core.CumulocitySession {
+	// Convert to core types
+	coreItem := core.Item{
+		ID:    item.ID,
+		Title: item.Title,
+		Tags:  item.Tags,
+		Vault: core.Vault{
+			ID:   item.Vault.ID,
+			Name: item.Vault.Name,
+		},
+	}
+
+	coreFields := core.ItemFields{
+		Username:   fields.username,
+		Password:   fields.password,
+		TOTPSecret: fields.totpSecret,
+		Tenant:     fields.tenant,
+	}
+
+	coreURLs := []core.URLSource{{
+		URL:     urlSource.URL,
+		Label:   urlSource.Label,
+		Primary: urlSource.Primary,
+		Source:  urlSource.Source,
+	}}
+
+	// Use the core function with tag filtering
+	sessions := core.MapToSessions(coreItem, coreFields, coreURLs, vaultName, c.Tags)
+
+	// Return the first session (there should only be one for a single URL)
+	if len(sessions) > 0 {
+		return sessions[0]
+	}
+
+	// This shouldn't happen in normal usage
+	return &core.CumulocitySession{}
+}

--- a/pkg/onepassword/client_test.go
+++ b/pkg/onepassword/client_test.go
@@ -241,7 +241,7 @@ func TestMapToSessions_MultipleURLs(t *testing.T) {
 		if session.ItemID != "test123" {
 			t.Errorf("Session %d: Expected ItemID 'test123', got '%s'", i, session.ItemID)
 		}
-		if !strings.Contains(session.SessionURI, "Test Vault/Test Service") {
+		if !strings.Contains(session.SessionURI, "vault123/test123") {
 			t.Errorf("Session %d: Expected SessionURI to contain vault/item, got '%s'", i, session.SessionURI)
 		}
 	}

--- a/pkg/onepassword/client_test.go
+++ b/pkg/onepassword/client_test.go
@@ -3,6 +3,8 @@ package onepassword
 import (
 	"strings"
 	"testing"
+
+	"github.com/thomaswinkler/c8y-session-1password/pkg/core"
 )
 
 func TestIsUID(t *testing.T) {
@@ -385,4 +387,48 @@ func TestOPItem_Skip_WithFallbackURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test helper function for backward compatibility with existing tests
+func mapToSessions(item *OPItem, vaults map[string]string) []*core.CumulocitySession {
+	// Convert to core types
+	coreItem := core.Item{
+		ID:    item.ID,
+		Title: item.Title,
+		Tags:  item.Tags,
+		Vault: core.Vault{
+			ID:   item.Vault.ID,
+			Name: item.Vault.Name,
+		},
+	}
+
+	// Extract fields
+	fields := item.extractFields()
+	coreFields := core.ItemFields{
+		Username:   fields.username,
+		Password:   fields.password,
+		TOTPSecret: fields.totpSecret,
+		Tenant:     fields.tenant,
+	}
+
+	// Collect URLs
+	allURLs := item.collectURLs()
+	coreURLs := make([]core.URLSource, len(allURLs))
+	for i, url := range allURLs {
+		coreURLs[i] = core.URLSource{
+			URL:     url.URL,
+			Label:   url.Label,
+			Primary: url.Primary,
+			Source:  url.Source,
+		}
+	}
+
+	// Determine vault name for URI
+	vaultName := item.Vault.Name
+	if name, found := vaults[item.Vault.ID]; found {
+		vaultName = name
+	}
+
+	// No tag filtering for backward compatibility
+	return core.MapToSessions(coreItem, coreFields, coreURLs, vaultName, nil)
 }

--- a/pkg/onepassword/list_sort_test.go
+++ b/pkg/onepassword/list_sort_test.go
@@ -1,0 +1,113 @@
+package onepassword
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/thomaswinkler/c8y-session-1password/pkg/core"
+)
+
+func TestClient_List_SortsByHost(t *testing.T) {
+	// Create multiple items with different hosts to test sorting
+	item1 := &OPItem{
+		ID:       "item1",
+		Title:    "Z Item",
+		Category: "LOGIN",
+		Vault: OPVault{
+			ID:   "vault1",
+			Name: "TestVault",
+		},
+		URLs: []OPURL{
+			{Label: "Production", Primary: true, Href: "https://zzz.example.com"},
+		},
+		Fields: []OPField{
+			{ID: "username", Value: "user1"},
+			{ID: "password", Value: "pass1"},
+		},
+		Tags: []string{"c8y"},
+	}
+
+	item2 := &OPItem{
+		ID:       "item2",
+		Title:    "A Item",
+		Category: "LOGIN",
+		Vault: OPVault{
+			ID:   "vault1",
+			Name: "TestVault",
+		},
+		URLs: []OPURL{
+			{Label: "Production", Primary: true, Href: "https://aaa.example.com"},
+		},
+		Fields: []OPField{
+			{ID: "username", Value: "user2"},
+			{ID: "password", Value: "pass2"},
+		},
+		Tags: []string{"c8y"},
+	}
+
+	item3 := &OPItem{
+		ID:       "item3",
+		Title:    "M Item",
+		Category: "LOGIN",
+		Vault: OPVault{
+			ID:   "vault1",
+			Name: "TestVault",
+		},
+		URLs: []OPURL{
+			{Label: "Production", Primary: true, Href: "https://mmm.example.com"},
+		},
+		Fields: []OPField{
+			{ID: "username", Value: "user3"},
+			{ID: "password", Value: "pass3"},
+		},
+		Tags: []string{"c8y"},
+	}
+
+	vaults := map[string]string{"vault1": "TestVault"}
+
+	// Create sessions from items
+	sessions1 := mapToSessions(item1, vaults)
+	sessions2 := mapToSessions(item2, vaults)
+	sessions3 := mapToSessions(item3, vaults)
+
+	// Combine sessions in non-alphabetical order (by host)
+	allSessions := make([]*core.CumulocitySession, 0)
+	allSessions = append(allSessions, sessions1...) // zzz.example.com
+	allSessions = append(allSessions, sessions2...) // aaa.example.com
+	allSessions = append(allSessions, sessions3...) // mmm.example.com
+
+	// Verify initial order is not alphabetical by host
+	if allSessions[0].Host != "https://zzz.example.com" {
+		t.Errorf("Expected first session to be zzz.example.com (unsorted), got %s", allSessions[0].Host)
+	}
+
+	// Simulate the sorting that happens in List()
+	sort.Slice(allSessions, func(i, j int) bool {
+		return allSessions[i].Host < allSessions[j].Host
+	})
+
+	// Verify sessions are now sorted alphabetically by Host
+	expectedHosts := []string{
+		"https://aaa.example.com",
+		"https://mmm.example.com",
+		"https://zzz.example.com",
+	}
+
+	if len(allSessions) != 3 {
+		t.Fatalf("Expected 3 sessions, got %d", len(allSessions))
+	}
+
+	for i, expectedHost := range expectedHosts {
+		if allSessions[i].Host != expectedHost {
+			t.Errorf("Session %d: Expected host '%s', got '%s'", i, expectedHost, allSessions[i].Host)
+		}
+	}
+
+	// Verify corresponding item names are correctly associated
+	expectedNames := []string{"A Item", "M Item", "Z Item"}
+	for i, expectedName := range expectedNames {
+		if allSessions[i].ItemName != expectedName {
+			t.Errorf("Session %d: Expected item name '%s', got '%s'", i, expectedName, allSessions[i].ItemName)
+		}
+	}
+}


### PR DESCRIPTION
The item list is now sorted by url. This is to help finding items, especially if there is more than one item for the same url found in the configured vaults. The item details presented in the list has been reduced and normalized to make it easier for items with long names. 