### PR TITLE
feat: add hidden flags which are unused but are required for go-c8y-cli compatibility

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -281,6 +281,13 @@ func init() {
 	rootCmd.PersistentFlags().Bool("noColor", false, "Disable colored output in picker (go-c8y-cli compatibility)")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose logging")
 	rootCmd.PersistentFlags().Bool("debug", false, "Debug logging")
+
+	// Hidden flags which are only there to satisfy the go-c8y-cli session interface
+	rootCmd.PersistentFlags().String("loginType", "", "Not used (hidden)")
+	rootCmd.PersistentFlags().Bool("clear", false, "Not used (hidden)")
+	_ = rootCmd.PersistentFlags().MarkHidden("loginType")
+	_ = rootCmd.PersistentFlags().MarkHidden("clear")
+
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(debugColorsCmd)
 }


### PR DESCRIPTION
The two hidden flags to satify the upcoming go-c8y-cli session provider interface, `--clear` and `--loginType`, but since they are not applicable to the provider, they do nothing and will not show up in the help text.